### PR TITLE
no need to check platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,14 +5,7 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0" CACHE STRING "Minimum macOS version")
 
 add_subdirectory(libs/JUCE)
 
-# Platform-specific plugin formats
-if(APPLE)
-    set(KR106_FORMATS AU VST3 Standalone)
-elseif(UNIX)
-    set(KR106_FORMATS VST3 LV2 Standalone)
-else()
-    set(KR106_FORMATS VST3 Standalone)
-endif()
+set(KR106_FORMATS AU VST3 LV2 Standalone)
 
 juce_add_plugin(KR106
     COMPANY_NAME "Kayrock"


### PR DESCRIPTION
As mentioned on Discord: JUCE only creates AU when building on macOS, so this can be simplified to one line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified plugin format configuration to consistently build AU, VST3, LV2, and Standalone formats across all platforms, removing platform-specific build variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->