### PR TITLE
add LV2 and CLAP to release

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -37,6 +37,7 @@ jobs:
           name: KR106-linux-x86_64
           path: |
             build/KR106_artefacts/**/VST3/
+            build/KR106_artefacts/**/CLAP/
             build/KR106_artefacts/**/LV2/
             build/KR106_artefacts/**/Standalone/
 
@@ -69,6 +70,6 @@ jobs:
           name: KR106-linux-arm64
           path: |
             build/KR106_artefacts/**/VST3/
-            build/KR106_artefacts/**/LV2/
             build/KR106_artefacts/**/CLAP/
+            build/KR106_artefacts/**/LV2/
             build/KR106_artefacts/**/Standalone/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,7 +177,6 @@ jobs:
           cp -R "$ARTS/VST3/Ultramaster KR-106.vst3" pkg/
           cp -R "$ARTS/CLAP/Ultramaster KR-106.clap" pkg/
           cp -R "$ARTS/LV2/Ultramaster KR-106.lv2" pkg/
-          cp -R "$ARTS/CLAP/Ultramaster KR-106.clap" pkg/
           cp -R "$ARTS/Standalone/Ultramaster KR-106" pkg/
           cat > pkg/INSTALL.txt << 'EOF'
           Ultramaster KR-106 — Linux Installation
@@ -185,7 +184,6 @@ jobs:
           VST3:       Copy the "Ultramaster KR-106.vst3" folder to ~/.vst3/
           CLAP:       Copy "Ultramaster KR-106.clap" to ~/.clap/
           LV2:        Copy the "Ultramaster KR-106.lv2" folder to ~/.lv2/
-          CLAP:       Copy the "Ultramaster KR-106.clap" folder to ~/.clap/
           Standalone: Put "Ultramaster KR-106" anywhere on your PATH.
 
           After copying, restart your DAW to scan for new plugins.


### PR DESCRIPTION
These are probably the right paths? Please check :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLAP and LV2 plugin artifacts are now included in build uploads.
  * LV2 plugins on macOS receive additional stapling after notarization for smoother installs.

* **Chores**
  * CI/release workflows updated to package, staple, and upload the additional plugin artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->