### PR TITLE
Add aarch64 build for Linux (Raspberry Pi) and upload

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -5,7 +5,14 @@ on:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-latest
+          - arch: aarch64
+            runner: ubuntu-22.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -26,3 +33,9 @@ jobs:
 
       - name: Build
         run: cmake --build build --config Release
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-${{ matrix.arch }}
+          path: build/


### PR DESCRIPTION
* Add aarch64 build for Linux (Raspberry Pi)
* Upload artifact

Tested on Raspberry Pi 500 in REAPER

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build infrastructure to support multiple processor architectures with automated artifact storage for each architecture variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->